### PR TITLE
Fix: GitHub Action binary build process and Makefile

### DIFF
--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -1,6 +1,8 @@
 name: New release with binaries
 
-on: push
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -1,8 +1,6 @@
-name: Go build and create release
+name: New release with binaries
 
-on:
-  push:
-    branches: [ master ]
+on: push
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,7 @@ check-misspell:
 build-latest: build-latest-darwin build-latest-linux
 
 .PHONY: build-latest-darwin
-build-latest-darwin: build-latest-darwin-386 build-latest-darwin-amd64
-
-.PHONY: build-latest-darwin-386
-build-latest-darwin-386:
-	$(LATEST_DARWIN_BUILD) 386
+build-latest-darwin: build-latest-darwin-amd64
 
 .PHONY: build-latest-darwin-amd64
 build-latest-darwin-amd64:
@@ -62,11 +58,7 @@ build-latest-linux-arm64:
 build-new-version: build-new-version-darwin build-new-version-linux
 
 .PHONY: build-new-version-darwin
-build-new-version-darwin: build-new-version-darwin-386 build-new-version-darwin-amd64
-
-.PHONY: build-new-version-darwin-386
-build-new-version-darwin-386:
-	$(NEW_VERSION_BUILD_DARWIN) 386
+build-new-version-darwin: build-new-version-darwin-amd64
 
 .PHONY: build-new-version-darwin-amd64
 build-new-version-darwin-amd64:


### PR DESCRIPTION
Fixes a problem in the Makefile and release and binary build process for the GitHub actions workflow. `darwin 386` as OS/Arch combination is not anymore supported and needed.