### PR TITLE
Fix: GitHub Workflow go_build_and_release

### DIFF
--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -1,8 +1,6 @@
 name: New release with binaries
 
-on:
-  push:
-    branches: [ master ]
+on: push
 
 jobs:
   build:
@@ -29,11 +27,9 @@ jobs:
     - name: Create info for the new release
       id: release_info
       run: |
-        sudo /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/nitschmann/releaser/master/scripts/install.sh)"
-
-        changelog=$(releaser changelog)
-        new_version=$(releaser new-version)
-        title=$(releaser title)
+        changelog=$(./.build/releaser-linux-amd64 changelog)
+        new_version=$(./.build/releaser-linux-amd64 new-version)
+        title=$(./.build/releaser-linux-amd64 title)
 
         changelog="${changelog//'%'/'%25'}"
         changelog="${changelog//$'\n'/'%0A'}"

--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -1,6 +1,8 @@
 name: New release with binaries
 
-on: push
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -50,16 +50,6 @@ jobs:
         body: |
           ${{ steps.release_info.outputs.changelog }}
 
-    - name: Upload release asset binary releaser-darwin-386
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./.build/releaser-darwin-386
-        asset_name: releaser-darwin-386
-        asset_content_type: application/binary
-
     - name: Upload release asset binary releaser-darwin-amd64
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
Fixes the GitHub Workflow `go_build_and_release` to get the correct information for the release info to be created. It uses the already compiled binary within the workflow. 