### PR TITLE
Fix: Print actual error message for Git command execution

### DIFF
--- a/internal/app/cmd/root.go
+++ b/internal/app/cmd/root.go
@@ -137,6 +137,6 @@ their corresponding logs.`,
 }
 
 func printCliErrorAndExit(msg interface{}) {
-	fmt.Println("An unexpected error occurred: ", msg)
+	fmt.Printf("An unexpected error occurred:\n%s", msg)
 	os.Exit(1)
 }

--- a/internal/app/git/error.go
+++ b/internal/app/git/error.go
@@ -1,0 +1,15 @@
+package git
+
+import "os/exec"
+
+// CmdError reports an unsuccessful execution of a git command with exec.Cmd
+type CmdError struct {
+	Cmd     *exec.Cmd
+	Err     error
+	Message string
+}
+
+// Error returns the actual Message of CmdError instance
+func (e CmdError) Error() string {
+	return e.Message
+}

--- a/internal/app/git/git.go
+++ b/internal/app/git/git.go
@@ -22,9 +22,14 @@ func New(executable string) Git {
 
 // ExecCommand executes a git command with the given args
 func (g Obj) ExecCommand(args []string) (string, error) {
-	output, err := exec.Command(g.Executable, args...).Output()
+	cmd := exec.Command(g.Executable, args...)
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", CmdError{
+			Cmd:     cmd,
+			Err:     err,
+			Message: string(output),
+		}
 	}
 
 	return strings.TrimSuffix(string(output[:]), "\n"), nil


### PR DESCRIPTION
Shows the actual error message when an error occurs for git command execution.