### PR TITLE
Fix: Build setup to support Darwin ARM64

### DIFF
--- a/.github/workflows/02_go_build_and_release.yml
+++ b/.github/workflows/02_go_build_and_release.yml
@@ -9,10 +9,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: ^1.16
       id: go
 
     - name: Check out code into the Go module directory
@@ -60,6 +60,16 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./.build/releaser-darwin-amd64
         asset_name: releaser-darwin-amd64
+        asset_content_type: application/binary
+
+    - name: Upload release asset binary releaser-darwin-arm64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./.build/releaser-darwin-arm64
+        asset_name: releaser-darwin-arm64
         asset_content_type: application/binary
 
     - name: Upload release asset binary releaser-linux-386

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,14 @@ check-misspell:
 build-latest: build-latest-darwin build-latest-linux
 
 .PHONY: build-latest-darwin
-build-latest-darwin: build-latest-darwin-amd64
+build-latest-darwin: build-latest-darwin-amd64 build-latest-darwin-arm64
 
 .PHONY: build-latest-darwin-amd64
 build-latest-darwin-amd64:
 	$(LATEST_DARWIN_BUILD) amd64
+
+.PHONY: build-latest-darwin-arm64
+	$(LATEST_DARWIN_BUILD) arm64
 
 .PHONY: build-latest-linux
 build-latest-linux: build-latest-linux-386 build-latest-linux-amd64 build-latest-linux-arm build-latest-linux-arm64
@@ -58,11 +61,15 @@ build-latest-linux-arm64:
 build-new-version: build-new-version-darwin build-new-version-linux
 
 .PHONY: build-new-version-darwin
-build-new-version-darwin: build-new-version-darwin-amd64
+build-new-version-darwin: build-new-version-darwin-amd64 build-new-version-darwin-arm64
 
 .PHONY: build-new-version-darwin-amd64
 build-new-version-darwin-amd64:
 	$(NEW_VERSION_BUILD_DARWIN) amd64
+
+.PHONY: build-new-version-darwin-arm64
+build-new-version-darwin-arm64:
+	$(NEW_VERSION_BUILD_DARWIN) arm64
 
 .PHONY: build-new-version-linux
 build-new-version-linux: build-new-version-linux-386 build-new-version-linux-amd64 build-new-version-linux-arm build-new-version-linux-arm64

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,7 @@ case $(uname -m) in
     i386)   architecture="386";;
     i686)   architecture="386";;
     x86_64) architecture="amd64";;
+    arm64)  architecture="arm64";;
     arm)    dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm";;
 esac
 


### PR DESCRIPTION
### Summary
* Update `Makefile` and build scripts to support compilation of binaries for `Darwin ARM64` (MacOS) architectures as well 