### PR TITLE
Fix: Add alias aarch64 for arm64 in scripts/install.sh

### DIFF
--- a/.github/workflows/01_ci.yml
+++ b/.github/workflows/01_ci.yml
@@ -6,7 +6,6 @@ jobs:
   lint:
     name: Golint
     runs-on: ubuntu-latest
-    needs: misspell
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v2
@@ -33,7 +32,6 @@ jobs:
   test:
     name: Go test
     runs-on: ubuntu-latest
-    needs: misspell
     steps:
       - name: Set up Go 1.14
         uses: actions/setup-go@v2

--- a/.github/workflows/01_ci.yml
+++ b/.github/workflows/01_ci.yml
@@ -3,32 +3,6 @@ name: CI
 on: push
 
 jobs:
-  misspell:
-    name: Check misspell
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        id: go
-        if: success()
-        with:
-          go-version: ^1.14
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        if: success()
-
-      - name: Install Go dependencies
-        id: go_dependencies
-        if: success()
-        run: |
-          go mod download
-          make install-test-dependencies
-
-      - name: Run misspell check
-        if: success()
-        run: make check-misspell
-
   lint:
     name: Golint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ NEW_VERSION_BUILD_LINUX=$(NEW_VERSION_BUILD) linux
 
 .PHONY: install-test-dependencies
 install-test-dependencies:
-	env GO111MODULE=on go get -u github.com/client9/misspell/cmd/misspell
 	env GO111MODULE=on go get -u golang.org/x/lint/golint
 
 .PHONY: test
@@ -20,10 +19,6 @@ test:
 .PHONY: lint
 lint:
 	golint -set_exit_status ./...
-
-.PHONY: check-misspell
-check-misspell:
-	misspell ./**/* -error
 
 .PHONY: build-latest
 build-latest: build-latest-darwin build-latest-linux

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,11 +30,13 @@ fi
 
 architecture=""
 case $(uname -m) in
+    aarch)   architecture="arm";;
+    aarch64) architecture="arm64";;
+    arm)    dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm";;
+    arm64)  architecture="arm64";;
     i386)   architecture="386";;
     i686)   architecture="386";;
     x86_64) architecture="amd64";;
-    arm64)  architecture="arm64";;
-    arm)    dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm";;
 esac
 
 if ! contains_element ${architecture} "${supported_architecture[@]}"; then


### PR DESCRIPTION
### Summary
Write a short summary what this pull request is about.

### Further notes & links
* Add `arm` and `arm64` alias for `aarchX` architecture for install script